### PR TITLE
Add cmake support to LodePNG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.0)
+
+# Project is not versioned, so use date of last upstream commit.
+project(LodePNG LANGUAGES CXX VERSION "2018.10.29")
+
+set(LODEPNG_SRC "lodepng.cpp")
+
+set(LODEPNG_HEADERS "lodepng.h")
+
+add_library(lodepng ${LODEPNG_SRC} ${LODEPNG_HEADERS})
+
+target_include_directories(
+    lodepng
+    PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
+)
+
+target_compile_definitions(lodepng PUBLIC "LODEPNG_DEBUG=$<CONFIG:Debug>")
+
+# Introduce variables:
+# * CMAKE_INSTALL_LIBDIR
+# * CMAKE_INSTALL_BINDIR
+include(GNUInstallDirs)
+
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(INCLUDE_INSTALL_DIR "include")
+
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(NAMESPACE "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${VERSION_CONFIG}" COMPATIBILITY ExactVersion
+)
+
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${PROJECT_CONFIG}"
+    INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+install(
+    TARGETS lodepng
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    INCLUDES DESTINATION "${INCLUDE_INSTALL_DIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)
+
+install(
+    FILES ${LODEPNG_HEADERS}
+    DESTINATION ${INCLUDE_INSTALL_DIR}/lodepng
+)
+
+install(
+    FILES "${PROJECT_CONFIG}" "${VERSION_CONFIG}"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${NAMESPACE}"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 # Project is not versioned, so use date of last upstream commit.
-project(LodePNG LANGUAGES CXX VERSION "2018.10.29")
+project(LodePNG LANGUAGES CXX VERSION "0.0.0")
 
 set(LODEPNG_SRC "lodepng.cpp")
 
@@ -20,6 +20,7 @@ target_compile_definitions(lodepng PUBLIC "LODEPNG_DEBUG=$<CONFIG:Debug>")
 # Introduce variables:
 # * CMAKE_INSTALL_LIBDIR
 # * CMAKE_INSTALL_BINDIR
+# * CMAKE_INSTALL_INCLUDEDIR
 include(GNUInstallDirs)
 
 set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
@@ -27,7 +28,6 @@ set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
 set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
 
 set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-set(INCLUDE_INSTALL_DIR "include")
 
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 set(NAMESPACE "${PROJECT_NAME}::")
@@ -46,7 +46,7 @@ configure_package_config_file(
 install(
     TARGETS lodepng
     EXPORT "${TARGETS_EXPORT_NAME}"
-    INCLUDES DESTINATION "${INCLUDE_INSTALL_DIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -54,7 +54,7 @@ install(
 
 install(
     FILES ${LODEPNG_HEADERS}
-    DESTINATION ${INCLUDE_INSTALL_DIR}/lodepng
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lodepng
 )
 
 install(

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,16 @@
+# Copyright (c) 2016, Ruslan Baratov
+#
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
This change adds support to build this library with cmake. Normally, we would contribute this upstream, but there are 3 PRs up to do that, and have not been answered:
- https://github.com/lvandeve/lodepng/pull/45
- https://github.com/lvandeve/lodepng/pull/78
- https://github.com/lvandeve/lodepng/pull/36

It's unclear if the author is receptive to adding CMake support or not.

This change will then allow the package to be used with Hunter.

Tested by pulling in and building/linking against lodepng in both debug and release projects.

After merge, can we make a release version, and then I will pull it in to hunter/hunter?